### PR TITLE
Api provides the ability to sort the articles in categories

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::ArticlesController < ApplicationController
       articles = Article.where(category: params['category'])
     end
     render json: articles, each_serializer: ArticlesIndexSerializer
+  rescue
+    render json: {message: "Unfortunatly this category doesn't exist."}, status: 422
   end
   
   def show

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::ArticlesController < ApplicationController
   def index
-    articles = Article.all
+    if params['category'].nil?
+      articles = Article.all
+    else
+      articles = Article.where(category: params['category'])
+    end
     render json: articles, each_serializer: ArticlesIndexSerializer
   end
   

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::ArticlesController < ApplicationController
   def index
-    if params['category'].nil?
-      articles = Article.all
-    else
+    if params['category']
       articles = Article.where(category: params['category'])
+    else
+      articles = Article.all
     end
     render json: articles, each_serializer: ArticlesIndexSerializer
   rescue

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :lead, :content
+  validates_presence_of :title, :lead, :content, :category
+  enum category: [:sports, :economy, :lifestyle]
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,4 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :lead, :content, :category
-  enum category: [:sports, :economy, :lifestyle]
+  enum category: [:culture, :economy, :international, :lifestyle, :local, :sports]
 end

--- a/app/serializers/article_show_serializer.rb
+++ b/app/serializers/article_show_serializer.rb
@@ -1,3 +1,3 @@
 class ArticleShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lead, :content
+  attributes :id, :title, :lead, :content, :category
 end

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,3 +1,3 @@
 class ArticlesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lead
+  attributes :id, :title, :lead, :category
 end

--- a/db/migrate/20200724093730_add_categories_to_articles.rb
+++ b/db/migrate/20200724093730_add_categories_to_articles.rb
@@ -1,0 +1,5 @@
+class AddCategoriesToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :category, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_150858) do
+ActiveRecord::Schema.define(version: 2020_07_24_093730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_150858) do
     t.string "title"
     t.string "lead"
     t.text "content"
+    t.integer "category"
   end
 
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "MyString" }
     lead { "MyText" } 
     content { "MyText" }
+    category { 1 }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :lead }
     it { is_expected.to have_db_column :content }
+    it { is_expected.to have_db_column :category }
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :lead }
     it { is_expected.to validate_presence_of :content }
+    it { is_expected.to validate_presence_of :category }
   end
 end

--- a/spec/requests/api/v1/articles/article_index_spec.rb
+++ b/spec/requests/api/v1/articles/article_index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "GET /v1/articles", type: :request do
   describe 'successfully gets articles' do
-    let!(:article_1) { create(:article, title: 'The first article', lead: 'This is the first article lead', category: 1) }
-    let!(:article_2) { create(:article, title: 'The second article', lead: 'This is the second article lead', category: 0) }
-    let!(:article_3) { create(:article, title: 'The third article', lead: 'This is the third article lead', category: 2) }
+    let!(:article_1) { create(:article, title: 'The first article', lead: 'This is the first article lead', category: 'economy') }
+    let!(:article_2) { create(:article, title: 'The second article', lead: 'This is the second article lead', category: 'sports') }
+    let!(:article_3) { create(:article, title: 'The third article', lead: 'This is the third article lead', category: 'lifestyle') }
 
     before do
       get '/api/v1/articles'

--- a/spec/requests/api/v1/articles/article_index_spec.rb
+++ b/spec/requests/api/v1/articles/article_index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "GET /v1/articles", type: :request do
   describe 'successfully gets articles' do
-    let!(:article_1) { create(:article, title: 'The first article', lead: 'This is the first article lead') }
-    let!(:article_2) { create(:article, title: 'The second article', lead: 'This is the second article lead') }
-    let!(:article_3) { create(:article, title: 'The third article', lead: 'This is the third article lead') }
+    let!(:article_1) { create(:article, title: 'The first article', lead: 'This is the first article lead', category: 'Economy') }
+    let!(:article_2) { create(:article, title: 'The second article', lead: 'This is the second article lead', category: 'Sports') }
+    let!(:article_3) { create(:article, title: 'The third article', lead: 'This is the third article lead', category: 'Lifestyle') }
 
     before do
       get '/api/v1/articles'
@@ -22,6 +22,12 @@ RSpec.describe "GET /v1/articles", type: :request do
 
     it 'should return third article lead' do
       expect(response_json["articles"].last["lead"]).to eq "This is the third article lead"
+    end
+
+    it 'articles should have categories' do
+      expect(response_jsons["articles"].first["category"]).to eq "Economy"
+      expect(response_jsons["articles"].second["category"]).to eq "Sports"
+      expect(response_jsons["articles"].last["category"]).to eq "Lifestyle"
     end
   end
 

--- a/spec/requests/api/v1/articles/article_index_spec.rb
+++ b/spec/requests/api/v1/articles/article_index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "GET /v1/articles", type: :request do
   describe 'successfully gets articles' do
-    let!(:article_1) { create(:article, title: 'The first article', lead: 'This is the first article lead', category: 'Economy') }
-    let!(:article_2) { create(:article, title: 'The second article', lead: 'This is the second article lead', category: 'Sports') }
-    let!(:article_3) { create(:article, title: 'The third article', lead: 'This is the third article lead', category: 'Lifestyle') }
+    let!(:article_1) { create(:article, title: 'The first article', lead: 'This is the first article lead', category: 1) }
+    let!(:article_2) { create(:article, title: 'The second article', lead: 'This is the second article lead', category: 0) }
+    let!(:article_3) { create(:article, title: 'The third article', lead: 'This is the third article lead', category: 2) }
 
     before do
       get '/api/v1/articles'
@@ -25,9 +25,9 @@ RSpec.describe "GET /v1/articles", type: :request do
     end
 
     it 'articles should have categories' do
-      expect(response_jsons["articles"].first["category"]).to eq "Economy"
-      expect(response_jsons["articles"].second["category"]).to eq "Sports"
-      expect(response_jsons["articles"].last["category"]).to eq "Lifestyle"
+      expect(response_json["articles"].first["category"]).to eq "economy"
+      expect(response_json["articles"].second["category"]).to eq "sports"
+      expect(response_json["articles"].last["category"]).to eq "lifestyle"
     end
   end
 

--- a/spec/requests/api/v1/articles/article_index_spec.rb
+++ b/spec/requests/api/v1/articles/article_index_spec.rb
@@ -24,9 +24,15 @@ RSpec.describe "GET /v1/articles", type: :request do
       expect(response_json["articles"].last["lead"]).to eq "This is the third article lead"
     end
 
-    it 'articles should have categories' do
+    it 'article 1 should have category economy' do
       expect(response_json["articles"].first["category"]).to eq "economy"
+    end
+
+    it 'article 2 should have category sports' do
       expect(response_json["articles"].second["category"]).to eq "sports"
+    end
+
+    it 'article 3 should have category lifestyle' do
       expect(response_json["articles"].last["category"]).to eq "lifestyle"
     end
   end

--- a/spec/requests/api/v1/articles/article_index_spec.rb
+++ b/spec/requests/api/v1/articles/article_index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "GET /v1/articles", type: :request do
       expect(response).to have_http_status 200
     end
 
-    it 'should return article' do
+    it 'should return articles' do
       expect(response_json["articles"].count).to eq 3
     end
 

--- a/spec/requests/api/v1/articles/show_article_spec.rb
+++ b/spec/requests/api/v1/articles/show_article_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "GET /v1/articles", type: :request do
-  let!(:article) { create(:article, title: 'The first article', lead: 'This is the first article lead', content: 'This is the first article content', category: 0) }
+  let!(:article) { create(:article, title: 'The first article', lead: 'This is the first article lead', content: 'This is the first article content', category: "sports") }
 
   describe 'successfully gets article' do
     before do

--- a/spec/requests/api/v1/articles/show_article_spec.rb
+++ b/spec/requests/api/v1/articles/show_article_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "GET /v1/articles", type: :request do
     it 'shows article content' do
       expect(response_json['article']['content']).to eq 'This is the first article content'
     end
+
+    it 'shows article category' do
+      expect(response_json['article']['category']).to eq 'sports'
+    end
   end
 
   describe 'unsuccessfully gets article' do

--- a/spec/requests/api/v1/articles/show_article_spec.rb
+++ b/spec/requests/api/v1/articles/show_article_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "GET /v1/articles", type: :request do
-  let!(:article) { create(:article, title: 'The first article', lead: 'This is the first article lead', content: 'This is the first article content') }
+  let!(:article) { create(:article, title: 'The first article', lead: 'This is the first article lead', content: 'This is the first article content', category: 0) }
 
   describe 'successfully gets article' do
     before do

--- a/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
+++ b/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe'GET /api/v1/articles/', type: :request do
   describe'successfully'do
   before do
     get "/api/v1/articles",
-    params:(category: "sports")
+    params:{category: "sports"}
   end
     it'responds with a 200 status'do
     expect(response).to have_http_status 200

--- a/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
+++ b/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe'GET /api/v1/articles/', type: :request do
 
     it 'responds with error message' do
       expect(response_json["message"]).to eq "Unfortunatly this category doesn't exist."
-      end
+    end
   end
 end

--- a/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
+++ b/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
@@ -1,29 +1,33 @@
 RSpec.describe'GET /api/v1/articles/', type: :request do
-  let!(:article) { create(:article, category: 0) }
-  let!(:article1) { create(:article, category: 0) }
-  let!(:article2) { create(:article, category: 1) }
+  let!(:article) { create(:article, category: 'sports') }
+  let!(:article1) { create(:article, category: 'sports') }
+  let!(:article2) { create(:article, category: 'economy') }
 
   describe'successfully'do
-  before do
-    get "/api/v1/articles",
-    params:{category: "sports"}
-  end
-    it'responds with a 200 status'do
-    expect(response).to have_http_status 200
+    before do
+      get "/api/v1/articles",
+      params:{category: "sports"}
     end
 
-    it 'should return articles with category sports' do
-      expect(response_json["articles"].count).to eq 2
-    end
+      it 'responds with a 200 status'do
+        expect(response).to have_http_status 200
+      end
+
+      it 'should return articles with category sports' do
+        expect(response_json["articles"].count).to eq 2
+      end
   end
+
   describe'unsuccessfully' do
     before do
       get "/api/v1/articles",
       params:{category: "latest news"}
     end
-    it'responds with a 422 status' do
+
+    it 'responds with a 422 status' do
       expect(response).to have_http_status 422 
     end
+
     it 'responds with error message' do
       expect(response_json["message"]).to eq "Unfortunatly this category doesn't exist."
       end

--- a/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
+++ b/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe'GET /api/v1/articles/', type: :request do
       expect(response_json["articles"].count).to eq 2
     end
   end
+  describe'unsuccessfully' do
+    before do
+      get "/api/v1/articles",
+      params:{category: "latest news"}
+    end
+    it'responds with a 422 status' do
+      expect(response).to have_http_status 422 
+    end
+    it 'responds with error message' do
+      expect(response_json["message"]).to eq "Unfortunatly this category doesn't exist."
+      end
+  end
 end

--- a/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
+++ b/spec/requests/api/v1/articles/user_can_request_articles_in_specific_category_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe'GET /api/v1/articles/', type: :request do
+  let!(:article) { create(:article, category: 0) }
+  let!(:article1) { create(:article, category: 0) }
+  let!(:article2) { create(:article, category: 1) }
+
+  describe'successfully'do
+  before do
+    get "/api/v1/articles",
+    params:(category: "sports")
+  end
+    it'responds with a 200 status'do
+    expect(response).to have_http_status 200
+    end
+
+    it 'should return articles with category sports' do
+      expect(response_json["articles"].count).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
## https://www.pivotaltracker.com/story/show/173920611
### User Story
```
As a Newspaper api
in order to give the readers better sorted articles
I want to be able to send the articles categorized
```
## Changes proposed in this pull request:
* Adding category to article database
* Adding enum to article model
* Adding test in index_spec to test article having a category
* Adding category to serializer
* Adding category to database column and validation
## What I have learned working on this feature:
* We have learned to work with enum
* We have practiced adding categories to objects
## Packages/Gems added
-  N/A
