### PR TITLE
[Example code] Truncate premium articles for non subscribers & more

### DIFF
--- a/app/controllers/api/v1/admin/articles_controller.rb
+++ b/app/controllers/api/v1/admin/articles_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::Admin::ArticlesController < ApplicationController
   private 
     
   def article_params
-    params.require(:article).permit(:title, :lead, :content, :category, :published)
+    params.require(:article).permit(:location, :premium, :title, :lead, :content, :category, :published)
   end
     
   def authorize_journalist

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -16,7 +16,8 @@ class Api::V1::ArticlesController < ApplicationController
   
   def show
     article = Article.find(params[:id])
-      render json: article, serializer: ArticleShowSerializer
+      
+    render json: article, serializer: ArticleShowSerializer
   rescue
       render json: {message: "Unfortunatly the article you were looking for could not be found."}, status: 422
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,6 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :lead, :content, :category
+  validates_inclusion_of :premium, in: [true, false]
   enum category: [:culture, :economy, :international, :lifestyle, :sports]
   belongs_to :journalist, class_name: "User"
 

--- a/app/serializers/article_show_serializer.rb
+++ b/app/serializers/article_show_serializer.rb
@@ -1,5 +1,6 @@
 class ArticleShowSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
+  include ActionView::Helpers::TextHelper
   attributes :id, :title, :lead, :content, :category, :image
   
   def image
@@ -8,6 +9,18 @@ class ArticleShowSerializer < ActiveModel::Serializer
       rails_blob_url(object.image)
     else
       object.image.service_url(expires_in:1.hour, disposition: 'inline')
+    end
+  end
+
+  def content
+    unless object.premium 
+      object.content
+    else
+      if current_user.nil? || !current_user.subscriber?
+        truncate(object.content, length: 50)
+      else
+        object.content
+      end
     end
   end
 end

--- a/db/migrate/20200821112224_add_premium_to_articles.rb
+++ b/db/migrate/20200821112224_add_premium_to_articles.rb
@@ -1,0 +1,5 @@
+class AddPremiumToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :premium, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_183214) do
+ActiveRecord::Schema.define(version: 2020_08_21_112224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_183214) do
     t.bigint "journalist_id"
     t.boolean "published", default: false
     t.string "location"
+    t.boolean "premium"
     t.index ["journalist_id"], name: "index_articles_on_journalist_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,48 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Article.destroy_all
+User.destroy_all
+
+journalist = User.create(email: 'journalist@mail.com', role: 'journalist', password: 'password')
+editor = User.create(email: 'editor@mail.com', role: 'editor', password: 'editor')
+registered = User.create(email: 'registered@mail.com', role: 'registered', password: 'editor')
+subscriber = User.create(email: 'subscriber@mail.com', role: 'subscriber', password: 'editor')
+
+premium_article = Article.create(
+  title: 'U cant imagine what this monkey did in the grocery store',
+  lead: 'Omg u need to read this lol',
+  content: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.' * 10,
+  category: 'lifestyle',
+  published: true,
+  premium: true,
+  location: 'Sweden',
+  journalist_id: journalist.id
+)
+file = URI.open('https://i.ytimg.com/vi/M3zRXaGEQEA/hqdefault.jpg')
+premium_article.image.attach(io: file, filename: 'monkey.jpg')
+
+free_article = Article.create(
+  title: 'World is burning',
+  lead: 'as usual',
+  content: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.' * 10,
+  category: 'international',
+  published: true,
+  premium: false,
+  location: 'USA',
+  journalist_id: journalist.id
+)
+file = URI.open('https://networkingnerd.files.wordpress.com/2016/09/dumpsterfire2.jpg?w=584&h=584')
+free_article.image.attach(io: file, filename: 'fire.jpg')
+
+unpublished_article = Article.create(
+  title: 'Bad and unpublished',
+  lead: 'This article is poorly written',
+  content: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.' * 10,
+  category: 'sports',
+  published: false,
+  premium: false,
+  location: 'Sweden',
+  journalist_id: journalist.id
+)
+file = URI.open('https://reputationresolutions.com/wp-content/uploads/2018/02/Screen-Shot-2019-05-01-at-6.06.55-PM.png')
+unpublished_article.image.attach(io: file, filename: 'bad.jpg')
+
+## You need to continue doing this with every possible type of article (category and locations)

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,10 +1,12 @@
 FactoryBot.define do
   factory :article do
+    premium { false }
     title { "MyString" }
     lead { "MyText" } 
     content { "MyText" }
     category { 1 }
-    published {true}
+    published { true }
+    location { 'Sweden' }
     association :journalist, factory: :user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :journalist_id }
     it { is_expected.to have_db_column :published }
     it { is_expected.to have_db_column :location }
+    it { is_expected.to have_db_column :premium }
   end
 
   describe 'Validations' do
@@ -21,5 +22,6 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :lead }
     it { is_expected.to validate_presence_of :content }
     it { is_expected.to validate_presence_of :category }
+    it { is_expected.to validate_inclusion_of(:premium).in_array([true, false])}
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe User, type: :model do
     it{is_expected.to have_db_column :email}
     it{is_expected.to have_db_column :encrypted_password}
   end
+  
   describe 'validations' do
     it {is_expected.to validate_presence_of :email}
     it {is_expected.to validate_presence_of :password}
   end
+
   describe 'Factory' do
     it 'should have valid factory' do
-    expect(FactoryBot.create(:user)).to be_valid
+      expect(FactoryBot.create(:user)).to be_valid
     end
   end
 end

--- a/spec/requests/api/v1/admin/create_spec.rb
+++ b/spec/requests/api/v1/admin/create_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe "POST /v1/admin/articles", type: :request do
         lead: 'All hail thy scrum lord',
         content: 'A good scrum lord will save us',
         category: 'lifestyle',
-        image: image
+        image: image,
+        premium: false,
+        location: 'Sweden'
        } 
       }, headers: journalist_headers 
     end
@@ -57,7 +59,9 @@ RSpec.describe "POST /v1/admin/articles", type: :request do
             title: '',
             lead: '',
             content: '',
-            category: ''
+            category: '',
+            premium: false,
+            location: 'Sweden'
           }
         }, headers: journalist_headers 
       end
@@ -80,7 +84,9 @@ RSpec.describe "POST /v1/admin/articles", type: :request do
             lead: 'All hail thy scrum lord',
             content: 'A good scrum lord will save us',
             category: 'lifestyle',
-            image: image 
+            image: image,
+            premium: false,
+            location: 'Sweden'
           }
         } 
       end
@@ -107,7 +113,9 @@ RSpec.describe "POST /v1/admin/articles", type: :request do
             lead: 'All hail thy scrum lord',
             content: 'A good scrum lord will save us',
             category: 'lifestyle',  
-            image: image
+            image: image,
+            premium: false,
+            location: 'Sweden'
           }
         }, headers: unauthorized_headers
       end

--- a/spec/requests/api/v1/articles/show_spec.rb
+++ b/spec/requests/api/v1/articles/show_spec.rb
@@ -1,5 +1,11 @@
 RSpec.describe "GET /v1/articles", type: :request do
-  let!(:article) { create(:article, title: 'The first article', lead: 'This is the first article lead', content: 'This is the first article content', category: "sports") }
+  let!(:article) { FactoryBot.create(
+    :article, 
+    title: 'The first article', 
+    lead: 'This is the first article lead', 
+    content: 'This is the first article content', 
+    category: "sports"
+  ) }
 
   describe 'successfully gets article' do
     before do

--- a/spec/requests/api/v1/articles/truncate_premuim_article_for_visitor_and_non_subscriber_spec.rb
+++ b/spec/requests/api/v1/articles/truncate_premuim_article_for_visitor_and_non_subscriber_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe "GET /v1/articles for premuim", type: :request do
+  let!(:article) { create(:article, premium: true, content: 'This is the first article content' * 50) }
+
+
+  describe 'successfully gets article' do
+    let!(:subscriber){create(:user, role: 'subscriber')}
+    let(:subscriber_credentials) { subscriber.create_new_auth_token }
+    let(:subscriber_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(subscriber_credentials) }
+  
+    before do
+      get "/api/v1/articles/#{article.id}", headers: subscriber_headers
+    end
+
+    it 'responds with 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'should respond with the whole content of the article' do
+      expect(response_json["article"]["content"].length).to eq 1650
+    end
+  end
+
+  describe 'non subscriber should not see the full content' do
+    let!(:user){create(:user, role: 'registered')}
+    let(:user_credentials) { user.create_new_auth_token }
+    let(:user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
+
+    before do
+      get "/api/v1/articles/#{article.id}", headers: user_headers
+    end
+
+    it 'responds with 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'should respond with the 50 charecters of the content' do
+      expect(response_json["article"]["content"].length).to eq 50
+    end
+  end
+
+  describe 'visitor should not see the full content' do
+    before do
+      get "/api/v1/articles/#{article.id}"
+    end
+
+    it 'responds with 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'should respond with the 50 charecters of the content' do
+      expect(response_json["article"]["content"].length).to eq 50
+    end
+  end
+end


### PR DESCRIPTION
- Truncate premium articles for non subscribers
- Add `:location` & `:premium` to create article action and tests
- How to add articles to seed file with image upload

I'm updating the create action here on the API. This means that you would have to update how you create articles on the frontend by adding those inputs for `:location` and `:premium`